### PR TITLE
Feature #527 met_base_image

### DIFF
--- a/internal/scripts/docker/Dockerfile
+++ b/internal/scripts/docker/Dockerfile
@@ -38,10 +38,33 @@ ENV PYTHONPATH "${PYTHONPATH}:/METviewer-python/METcalcpy/:/METviewer-python/MET
 ENV METPLOTPY_BASE "/METviewer-python/METplotpy/"
 
 #
+# Update the OS, as needed
+#
+RUN apt update && apt -y upgrade
+
+#
 # Clone the METviewer repository
 #
 RUN echo "Checking out METviewer ${METVIEWER_GIT_NAME} from ${METVIEWER_GIT_URL}"
 RUN git clone --branch ${METVIEWER_GIT_NAME} ${METVIEWER_GIT_URL} /METviewer
+
+#
+# Configure METviewer
+#
+RUN echo "Configuring METviewer" \
+ && cd /METviewer \
+ && cat webapp/metviewer/WEB-INF/classes/build.properties | \
+    sed -r 's%db.host=.*%db.host=mysql_mv%g' | \
+    sed -r 's%db.user=.*%db.user=root%g' | \
+    sed -r 's%db.password=.*%db.password=mvuser%g' | \
+    sed -r 's%db.management.system=.*%db.management.system=mysql%g' | \
+    sed -r 's%output.dir=.*%output.dir=/opt/tomcat/webapps/metviewer_output/%g' | \
+    sed -r 's%webapps.dir=.*%webapps.dir=/opt/tomcat/webapps/metviewer/%g' | \
+    sed -r 's%url.output=.*%url.output=http://localhost:8080/metviewer_output/%g' | \
+    sed -r 's%python.env=.*%python.env=/usr/%g' | \
+    sed -r 's%metcalcpy.home=.*%metcalcpy.home=/METviewer-python/METcalcpy/%g' | \
+    sed -r 's%metplotpy.home=.*%metplotpy.home=/METviewer-python/METplotpy/%g' \
+    > build.properties
 
 #
 # Run the build script

--- a/internal/scripts/docker/Dockerfile
+++ b/internal/scripts/docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM centos:7
+ARG MET_BASE_REPO=met-base
+ARG MET_BASE_TAG=v3.2
 
-MAINTAINER Tatiana Burek <tatiana@ucar.edu>
+FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
+MAINTAINER John Halley Gotway <johnhg@ucar.edu>
 
 #
 # This Dockerfile checks out METviewer and its dependencies from GitHub and builds the specified branch or tag.
@@ -41,30 +43,16 @@ ENV TOMCAT_MAJOR_VERSION 8
 ENV TOMCAT_VERSION ${TOMCAT_MAJOR_VERSION}.${TOMCAT_MINOR_VERSION}
 
 #
-# Install system updates
+# Update the OS, as needed
 #
-RUN yum -y update \
- && yum -y install epel-release \
- && yum -y install 'dnf-command(config-manager)' \
- && yum-config-manager --enable PowerTools
+RUN apt update \
+ && apt -y upgrade
+
 
 #
 # Install required packages
 #
-RUN yum -y install wget tar git ant java R mysql ksh \
- && rm -rf /var/cache/yum/* \
- && yum clean all
-
-#
-# Install gsl-2.5 on which the R gsl package depends.
-# The centos7 gal package is too old (version 1.5).
-#
-RUN echo "Compiling gsl-2.5" \
- && curl -SL http://gnu.askapache.com/gsl/gsl-2.5.tar.gz | tar zxC /lib \
- && cd /lib/gsl-2.5 \
- && ./configure --prefix=/usr --libdir=/usr/lib64 >& configure.log \
- && make >& make.log \
- && make install >& make_install.log
+RUN apt -y install ant r-base mariadb-server ksh
 
 #
 # Setup default cran repo

--- a/internal/scripts/docker/Dockerfile
+++ b/internal/scripts/docker/Dockerfile
@@ -5,8 +5,9 @@ FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
 MAINTAINER John Halley Gotway <johnhg@ucar.edu>
 
 #
-# This Dockerfile checks out METviewer and its dependencies from GitHub and builds the specified branch or tag.
-# Use the develop branches for dependencies by default but override with "--build-arg".
+# This Dockerfile checks out METviewer and its dependencies from GitHub and builds
+# the specified branch or tag. Use the develop branches for dependencies by default
+# but override with "--build-arg".
 #
 
 ARG METVIEWER_GIT_NAME
@@ -38,8 +39,8 @@ ENV METDATAIO_GIT_URL https://github.com/dtcenter/METdataio
 #
 # Constants
 #
-ENV TOMCAT_MINOR_VERSION 5.61
-ENV TOMCAT_MAJOR_VERSION 8
+ENV TOMCAT_MAJOR_VERSION 9
+ENV TOMCAT_MINOR_VERSION 0.89
 ENV TOMCAT_VERSION ${TOMCAT_MAJOR_VERSION}.${TOMCAT_MINOR_VERSION}
 
 #
@@ -48,11 +49,10 @@ ENV TOMCAT_VERSION ${TOMCAT_MAJOR_VERSION}.${TOMCAT_MINOR_VERSION}
 RUN apt update \
  && apt -y upgrade
 
-
 #
 # Install required packages
 #
-RUN apt -y install ant r-base mariadb-server ksh
+RUN apt -y install ant openjdk-17-jdk r-base mariadb-server ksh
 
 #
 # Setup default cran repo
@@ -98,7 +98,7 @@ WORKDIR /METviewer-python/
 RUN git clone --branch ${METDATAIO_GIT_NAME} ${METDATAIO_GIT_URL}
 
 #
-# Install METviewer
+# Install METviewer by cloning GitHub repository.
 #
 RUN echo "Checking out METviewer ${METVIEWER_GIT_NAME} from ${METVIEWER_GIT_URL}"
 RUN git clone --branch ${METVIEWER_GIT_NAME} ${METVIEWER_GIT_URL} /METviewer \
@@ -154,11 +154,11 @@ RUN git clone --branch ${METVIEWER_GIT_NAME} ${METVIEWER_GIT_URL} /METviewer \
 #
 # Create a link for python3
 #
-RUN ln -sf /usr/local/bin/python3.10  /usr/bin/python3
-RUN ln -sf /usr/bin/python3  /usr/bin/python
+RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python3
+RUN ln -sf /usr/bin/python3 /usr/bin/python
 
-RUN ln -sf /usr/local/bin/pip3.10  /usr/bin/pip3
-RUN ln -sf /usr/bin/pip3  /usr/bin/pip
+RUN ln -sf /usr/local/bin/pip3.10 /usr/bin/pip3
+RUN ln -sf /usr/bin/pip3 /usr/bin/pip
 
 #
 # Install GEOS - needed for cartopy

--- a/internal/scripts/docker/Dockerfile
+++ b/internal/scripts/docker/Dockerfile
@@ -152,29 +152,6 @@ RUN git clone --branch ${METVIEWER_GIT_NAME} ${METVIEWER_GIT_URL} /METviewer \
  && mv mv_prune.sh-DOCKER mv_prune.sh
 
 #
-# Install Python 3.10.4
-#
-RUN yum install gcc openssl11 openssl11-devel libreadline-gplv2-dev libncursesw5-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev openssl-devel libssl-dev bzip2-devel libffi-devel zlib-devel libproj-dev proj-data proj-bin libgeos-dev bzip2 -y
-RUN mkdir /usr/local/openssl11
-WORKDIR /usr/local/openssl11
-RUN ln -s /usr/lib64/openssl11 lib
-RUN ln -s /usr/include/openssl11 include
-
-RUN curl https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz --output /tmp/Python-3.10.4.tgz
-WORKDIR /tmp
-RUN tar xzf Python-3.10.4.tgz
-WORKDIR /tmp/Python-3.10.4
-RUN ./configure --enable-optimizations --with-openssl=/usr/local/openssl11
-RUN yum install make -y
-RUN make altinstall
-RUN yum install which -y
-WORKDIR /tmp
-RUN rm -r Python-3.10.4.tgz
-RUN yum -y install epel-release
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py | python3.10
-RUN python3.10 -m pip install --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host pypi.org --upgrade pip
-
-#
 # Create a link for python3
 #
 RUN ln -sf /usr/local/bin/python3.10  /usr/bin/python3

--- a/internal/scripts/docker/Dockerfile
+++ b/internal/scripts/docker/Dockerfile
@@ -23,191 +23,18 @@ RUN if [ "x${METVIEWER_GIT_NAME}" = "x" ]; then \
       exit 1; \
     fi 
 
+ENV METVIEWER_GIT_URL https://github.com/dtcenter/METviewer
+ENV CATALINA_HOME /opt/tomcat
+
 RUN echo "Build Argument METVIEWER_GIT_NAME=${METVIEWER_GIT_NAME}" \
  && echo "Build Argument METPLOTPY_GIT_NAME=${METPLOTPY_GIT_NAME}" \
  && echo "Build Argument METCALCPY_GIT_NAME=${METCALCPY_GIT_NAME}" \
  && echo "Build Argument METDATAIO_GIT_NAME=${METDATAIO_GIT_NAME}"
 
 #
-# Repository URLs
+# Expose METviewer port
 #
-ENV METVIEWER_GIT_URL https://github.com/dtcenter/METviewer
-ENV METPLOTPY_GIT_URL https://github.com/dtcenter/METplotpy
-ENV METCALCPY_GIT_URL https://github.com/dtcenter/METcalcpy
-ENV METDATAIO_GIT_URL https://github.com/dtcenter/METdataio
-
-#
-# Constants
-#
-ENV TOMCAT_MAJOR_VERSION 9
-ENV TOMCAT_MINOR_VERSION 0.89
-ENV TOMCAT_VERSION ${TOMCAT_MAJOR_VERSION}.${TOMCAT_MINOR_VERSION}
-
-#
-# Update the OS, as needed
-#
-RUN apt update \
- && apt -y upgrade
-
-#
-# Install required packages
-#
-RUN apt -y install ant openjdk-17-jdk r-base mariadb-server ksh
-
-#
-# Setup default cran repo
-#
-RUN echo "r <- getOption('repos'); r['CRAN'] <- 'http://cran.us.r-project.org'; options(repos = r);" > ~/.Rprofile
-
-#
-# Install required R packages
-#
-RUN Rscript -e "install.packages('boot')" \
- && Rscript -e "install.packages('plotrix')" \
- && Rscript -e "install.packages('gsl')" \
- && Rscript -e "install.packages('data.table')" \
- && Rscript -e "install.packages('verification')"
-
-#
-# Install Tomcat
-#
-ENV CATALINA_HOME /opt/tomcat
-
-RUN wget https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz \
- && tar -xvf apache-tomcat-${TOMCAT_VERSION}.tar.gz \
- && rm apache-tomcat*.tar.gz \
- && mv apache-tomcat* ${CATALINA_HOME} \
- && chmod +x ${CATALINA_HOME}/bin/*sh
-
 EXPOSE 8080
-
-#
-# Install METplus python components
-#
-RUN mkdir /METviewer-python \
- && echo "Checking out METcalcpy ${METCALCPY_GIT_NAME} from ${METCALCPY_GIT_URL}"
-WORKDIR /METviewer-python/
-RUN git clone --branch ${METCALCPY_GIT_NAME} ${METCALCPY_GIT_URL}
-
-RUN echo "Checking out METplotpy ${METPLOTPY_GIT_NAME} from ${METPLOTPY_GIT_URL}"
-WORKDIR /METviewer-python/
-RUN git clone --branch ${METPLOTPY_GIT_NAME} ${METPLOTPY_GIT_URL}
-
-RUN echo "Checking out METdataio ${METDATAIO_GIT_NAME} from ${METDATAIO_GIT_URL}"
-WORKDIR /METviewer-python/
-RUN git clone --branch ${METDATAIO_GIT_NAME} ${METDATAIO_GIT_URL}
-
-#
-# Install METviewer by cloning GitHub repository.
-#
-RUN echo "Checking out METviewer ${METVIEWER_GIT_NAME} from ${METVIEWER_GIT_URL}"
-RUN git clone --branch ${METVIEWER_GIT_NAME} ${METVIEWER_GIT_URL} /METviewer \
- && echo "Configuring and building METviewer" \
- && cd /METviewer \
- && cat webapp/metviewer/WEB-INF/classes/build.properties | \
-    sed -r 's%db.host=.*%db.host=mysql_mv%g' | \
-    sed -r 's%db.user=.*%db.user=root%g' | \
-    sed -r 's%db.password=.*%db.password=mvuser%g' | \
-    sed -r 's%db.management.system=.*%db.management.system=mysql%g' | \
-    sed -r 's%output.dir=.*%output.dir=/opt/tomcat/webapps/metviewer_output/%g' | \
-    sed -r 's%webapps.dir=.*%webapps.dir=/opt/tomcat/webapps/metviewer/%g' | \
-    sed -r 's%url.output=.*%url.output=http://localhost:8080/metviewer_output/%g' | \
-    sed -r 's%python.env=.*%python.env=/usr/%g' | \
-    sed -r 's%metcalcpy.home=.*%metcalcpy.home=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%metplotpy.home=.*%metplotpy.home=/METviewer-python/METplotpy/%g' \
-    > build.properties \
- && ant -Dbuild.properties.file=./build.properties \
-        -Ddb.management.system=mysql \
-        -Dmetcalcpy.path=/METviewer-python/METcalcpy/ \
-        -Dmetplotpy.path=/METviewer-python/METplotpy/ \
-        -Dpython.env.path=/usr/ war \
- && mv /METviewer/dist/*.war ${CATALINA_HOME}/webapps \
- && echo "Configuring METviewer scripts" \
- && cd /METviewer/bin \
- && cat mv_batch.sh | \
-    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
-    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
-    >  mv_batch.sh-DOCKER \
- && mv mv_batch.sh-DOCKER mv_batch.sh \
- && cat mv_load.sh | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g'  | \
-    sed -r 's%METDATAIO_HOME=.*%METDATAIO_HOME=/METviewer-python/METdataio/%g' \
-    >  mv_load.sh-DOCKER \
- && mv mv_load.sh-DOCKER mv_load.sh \
- && cat mv_scorecard.sh | \
-    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
-    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
-    >  mv_scorecard.sh-DOCKER \
- && mv mv_scorecard.sh-DOCKER mv_scorecard.sh \
- && cat mv_prune.sh | \
-    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
-    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
-    >  mv_prune.sh-DOCKER \
- && mv mv_prune.sh-DOCKER mv_prune.sh
-
-#
-# Create a link for python3
-#
-RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python3
-RUN ln -sf /usr/bin/python3 /usr/bin/python
-
-RUN ln -sf /usr/local/bin/pip3.10 /usr/bin/pip3
-RUN ln -sf /usr/bin/pip3 /usr/bin/pip
-
-#
-# Install GEOS - needed for cartopy
-#
-WORKDIR /tmp
-RUN wget http://download.osgeo.org/geos/geos-3.7.2.tar.bz2
-RUN tar xjf geos-3.7.2.tar.bz2
-WORKDIR /tmp/geos-3.7.2
-RUN ./configure --enable-php; make clean ; make
-RUN make install
-RUN ldconfig
-WORKDIR /tmp
-RUN rm -r geos-3.7.2.tar.bz2
-
-#
-# Install Python packages
-#
-RUN pip install cartopy \
- && pip install eofs \
- && pip install imutils==0.5.4 \
- && pip install imageio==2.19.2 \
- && pip install lxml==4.9.1 \
- && pip install matplotlib==3.5.2 \
- && pip install netcdf4==1.6.2 \
- && pip install numpy==1.22.0 \
- && pip install pytest==7.1.2 \
- && pip install metpy==1.3.1 \
- && pip install pyyaml==6.0 \
- && pip install scikit-image==0.19.3 \
- && pip install scikit-learn \
- && pip install scipy==1.11.1 \
- && pip install xarray==2022.3.0 \
- && pip install PyMySQL==1.0.2 \
- && pip install pint==0.19.2 \
- && pip install plotly==5.9.0 \
- && pip install kaleido==0.2.1 \
- && pip install attrs==22.1.0 \
- && pip install exceptiongroup==1.0.4 \
- && pip install iniconfig==1.1.1 \
- && pip install packaging==22.0 \
- && pip install pluggy==1.0.0 \
- && pip install pytz==2022.6 \
- && pip install setuptools==65.5.1 \
- && pip install six==1.16.0 \
- && pip install tomli==2.0.1 \
- && pip install wheel==0.38.1 \
- && pip install python-dateutil==2.8.2 \
- && pip install opencv-python \
- && pip install pandas==1.5.2
 
 #
 # Set env vars
@@ -216,23 +43,16 @@ ENV PYTHONPATH "${PYTHONPATH}:/METviewer-python/METcalcpy/:/METviewer-python/MET
 ENV METPLOTPY_BASE "/METviewer-python/METplotpy/"
 
 #
-# Remove unneeded scripts
+# Clone the METviewer repository
 #
-RUN rm /METviewer/bin/auto_test.sh \
- && rm /METviewer/bin/mv_test.sh \
- && rm /METviewer/bin/nightly_test.sh \
- && rm /METviewer/bin/prep_dist.sh \
- && rm /METviewer/bin/mv_compare.sh \
- && rm -r /METviewer/test
+RUN echo "Checking out METviewer ${METVIEWER_GIT_NAME} from ${METVIEWER_GIT_URL}"
+RUN git clone --branch ${METVIEWER_GIT_NAME} ${METVIEWER_GIT_URL} /METviewer
 
 #
-# Change permissions of the scripts
+# Run the build script
 #
-RUN chmod 755 /METviewer/bin/mv_batch.sh \
- && chmod 755 /METviewer/bin/mv_load.sh \
- && chmod 755 /METviewer/bin/mv_prune.sh \
- && chmod 755 /METviewer/bin/mv_scorecard.sh
+RUN cd /METviewer \
+ && internal/scripts/docker/build_metviewer_docker.sh
 
-ENTRYPOINT ${CATALINA_HOME}/bin/startup.sh  && /bin/bash
+ENTRYPOINT ${CATALINA_HOME}/bin/startup.sh && /bin/bash
 CMD ["true"]
-

--- a/internal/scripts/docker/Dockerfile
+++ b/internal/scripts/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG MET_BASE_REPO=met-base
+ARG MET_BASE_REPO=met-base-metviewer
 ARG MET_BASE_TAG=v3.2
 
 FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
@@ -30,11 +30,6 @@ RUN echo "Build Argument METVIEWER_GIT_NAME=${METVIEWER_GIT_NAME}" \
  && echo "Build Argument METPLOTPY_GIT_NAME=${METPLOTPY_GIT_NAME}" \
  && echo "Build Argument METCALCPY_GIT_NAME=${METCALCPY_GIT_NAME}" \
  && echo "Build Argument METDATAIO_GIT_NAME=${METDATAIO_GIT_NAME}"
-
-#
-# Expose METviewer port
-#
-EXPOSE 8080
 
 #
 # Set env vars

--- a/internal/scripts/docker/Dockerfile.apptainer
+++ b/internal/scripts/docker/Dockerfile.apptainer
@@ -50,7 +50,7 @@ RUN apt update && apt -y upgrade
 #
 # Install additional packages for MariaDB server
 #
-RUN apt -y install --setopt=tsflags=nodocs mariadb-server bind9-utils pwgen psmisc hostname
+RUN apt -y install mariadb-server bind9-utils pwgen psmisc hostname
 
 #
 # Clone the METviewer repository

--- a/internal/scripts/docker/Dockerfile.apptainer
+++ b/internal/scripts/docker/Dockerfile.apptainer
@@ -1,10 +1,13 @@
-FROM centos:7
+ARG MET_BASE_REPO=met-base-metviewer
+ARG MET_BASE_TAG=v3.2
 
-MAINTAINER Tatiana Burek <tatiana@ucar.edu>
+FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
+MAINTAINER John Halley Gotway <johnhg@ucar.edu>
 
 #
-# This Dockerfile checks out METviewer and its dependencies from GitHub and builds the specified branch or tag.
-# Use the develop branches for dependencies by default but override with "--build-arg".
+# This Dockerfile checks out METviewer and its dependencies from GitHub and builds
+# the specified branch or tag. Use the develop branches for dependencies by default
+# but override with "--build-arg".
 #
 
 ARG METVIEWER_GIT_NAME
@@ -18,7 +21,10 @@ ARG METDATAIO_GIT_NAME=develop
 RUN if [ "x${METVIEWER_GIT_NAME}" = "x" ]; then \
       echo "ERROR: METVIEWER_GIT_NAME undefined! Rebuild with \"--build-arg METVIEWER_GIT_NAME={branch, tag, or hash}\""; \
       exit 1; \
-    fi
+    fi 
+
+ENV METVIEWER_GIT_URL https://github.com/dtcenter/METviewer
+ENV CATALINA_HOME /opt/tomcat
 
 RUN echo "Build Argument METVIEWER_GIT_NAME=${METVIEWER_GIT_NAME}" \
  && echo "Build Argument METPLOTPY_GIT_NAME=${METPLOTPY_GIT_NAME}" \
@@ -26,106 +32,36 @@ RUN echo "Build Argument METVIEWER_GIT_NAME=${METVIEWER_GIT_NAME}" \
  && echo "Build Argument METDATAIO_GIT_NAME=${METDATAIO_GIT_NAME}"
 
 #
-# Repository URLs
+# Set env vars
 #
-ENV METVIEWER_GIT_URL https://github.com/dtcenter/METviewer
-ENV METPLOTPY_GIT_URL https://github.com/dtcenter/METplotpy
-ENV METCALCPY_GIT_URL https://github.com/dtcenter/METcalcpy
-ENV METDATAIO_GIT_URL https://github.com/dtcenter/METdataio
+ENV PYTHONPATH "${PYTHONPATH}:/METviewer-python/METcalcpy/:/METviewer-python/METplotpy/"
+ENV METPLOTPY_BASE "/METviewer-python/METplotpy/"
 
 #
-# Constants
-#
-ENV TOMCAT_MINOR_VERSION 5.61
-ENV TOMCAT_MAJOR_VERSION 8
-ENV TOMCAT_VERSION ${TOMCAT_MAJOR_VERSION}.${TOMCAT_MINOR_VERSION}
-
-#
-# Install system updates
-#
-RUN yum -y update \
- && yum -y install epel-release \
- && yum -y install 'dnf-command(config-manager)' \
- && yum-config-manager --enable PowerTools
-
-#
-# Install MariaDB server
-#
-RUN yum -y install --setopt=tsflags=nodocs epel-release && \
-    yum -y install --setopt=tsflags=nodocs mariadb-server bind-utils pwgen psmisc hostname && \
-    yum -y erase vim-minimal && \
-    yum -y update && yum clean all
-
-#
-# Install required packages
+# Run as root
 #
 USER root
-RUN yum -y install wget tar git ant  R mysql ksh \
- && rm -rf /var/cache/yum/* \
- && yum clean all
-
-RUN yum install java-1.8.0-openjdk-devel
 
 #
-# Install gsl-2.5 on which the R gsl package depends.
-# The centos7 gal package is too old (version 1.5).
+# Update the OS, as needed
 #
-RUN echo "Compiling gsl-2.5" \
- && curl -SL http://gnu.askapache.com/gsl/gsl-2.5.tar.gz | tar zxC /lib \
- && cd /lib/gsl-2.5 \
- && ./configure --prefix=/usr --libdir=/usr/lib64 >& configure.log \
- && make >& make.log \
- && make install >& make_install.log
+RUN apt update && apt -y upgrade
 
 #
-# Setup default cran repo
+# Install additional packages for MariaDB server
 #
-RUN echo "r <- getOption('repos'); r['CRAN'] <- 'http://cran.us.r-project.org'; options(repos = r);" > ~/.Rprofile
+RUN apt -y install --setopt=tsflags=nodocs mariadb-server bind9-utils pwgen psmisc hostname
 
 #
-# Install required R packages
-#
-RUN Rscript -e "install.packages('boot')" \
- && Rscript -e "install.packages('plotrix')" \
- && Rscript -e "install.packages('gsl')" \
- && Rscript -e "install.packages('data.table')" \
- && Rscript -e "install.packages('verification')"
-
-#
-# Install Tomcat
-#
-ENV CATALINA_HOME /opt/tomcat
-
-RUN wget https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz \
- && tar -xvf apache-tomcat-${TOMCAT_VERSION}.tar.gz \
- && rm apache-tomcat*.tar.gz \
- && mv apache-tomcat* ${CATALINA_HOME} \
- && chmod +x ${CATALINA_HOME}/bin/*sh
-
-EXPOSE 8080
-
-#
-# Install METplus python components
-#
-RUN mkdir /METviewer-python \
- && echo "Checking out METcalcpy ${METCALCPY_GIT_NAME} from ${METCALCPY_GIT_URL}"
-WORKDIR /METviewer-python/
-RUN git clone --branch ${METCALCPY_GIT_NAME} ${METCALCPY_GIT_URL}
-
-RUN echo "Checking out METplotpy ${METPLOTPY_GIT_NAME} from ${METPLOTPY_GIT_URL}"
-WORKDIR /METviewer-python/
-RUN git clone --branch ${METPLOTPY_GIT_NAME} ${METPLOTPY_GIT_URL}
-
-RUN echo "Checking out METdataio ${METDATAIO_GIT_NAME} from ${METDATAIO_GIT_URL}"
-WORKDIR /METviewer-python/
-RUN git clone --branch ${METDATAIO_GIT_NAME} ${METDATAIO_GIT_URL}
-
-#
-# Install METviewer
+# Clone the METviewer repository
 #
 RUN echo "Checking out METviewer ${METVIEWER_GIT_NAME} from ${METVIEWER_GIT_URL}"
-RUN git clone --branch ${METVIEWER_GIT_NAME} ${METVIEWER_GIT_URL} /METviewer \
- && echo "Configuring and building METviewer" \
+RUN git clone --branch ${METVIEWER_GIT_NAME} ${METVIEWER_GIT_URL} /METviewer
+
+#
+# Configure METviewer
+#
+RUN echo "Configuring METviewer" \
  && cd /METviewer \
  && cat webapp/metviewer/WEB-INF/classes/build.properties | \
     sed -r 's%db.host=.*%db.host=localhost%g' | \
@@ -138,150 +74,13 @@ RUN git clone --branch ${METVIEWER_GIT_NAME} ${METVIEWER_GIT_URL} /METviewer \
     sed -r 's%python.env=.*%python.env=/usr/%g' | \
     sed -r 's%metcalcpy.home=.*%metcalcpy.home=/METviewer-python/METcalcpy/%g' | \
     sed -r 's%metplotpy.home=.*%metplotpy.home=/METviewer-python/METplotpy/%g' \
-    > build.properties \
- && ant -Dbuild.properties.file=./build.properties \
-        -Ddb.management.system=mysql \
-        -Dmetcalcpy.path=/METviewer-python/METcalcpy/ \
-        -Dmetplotpy.path=/METviewer-python/METplotpy/ \
-        -Dpython.env.path=/usr/ war \
- && mv /METviewer/dist/*.war ${CATALINA_HOME}/webapps \
- && echo "Configuring METviewer scripts" \
- && cd /METviewer/bin \
- && cat mv_batch.sh | \
-    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
-    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
-    >  mv_batch.sh-DOCKER \
- && mv mv_batch.sh-DOCKER mv_batch.sh \
- && cat mv_load.sh | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g'  | \
-    sed -r 's%METDATAIO_HOME=.*%METDATAIO_HOME=/METviewer-python/METdataio/%g' \
-    >  mv_load.sh-DOCKER \
- && mv mv_load.sh-DOCKER mv_load.sh \
- && cat mv_scorecard.sh | \
-    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
-    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
-    >  mv_scorecard.sh-DOCKER \
- && mv mv_scorecard.sh-DOCKER mv_scorecard.sh \
- && cat mv_prune.sh | \
-    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
-    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
-    >  mv_prune.sh-DOCKER \
- && mv mv_prune.sh-DOCKER mv_prune.sh
+    > build.properties
 
 #
-# Install Python 3.10.4
+# Run the build script
 #
-RUN yum install gcc openssl11 openssl11-devel libreadline-gplv2-dev libncursesw5-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev openssl-devel libssl-dev bzip2-devel libffi-devel zlib-devel libproj-dev proj-data proj-bin libgeos-dev bzip2 -y
-RUN mkdir /usr/local/openssl11
-WORKDIR /usr/local/openssl11
-RUN ln -s /usr/lib64/openssl11 lib
-RUN ln -s /usr/include/openssl11 include
-
-RUN curl https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz --output /tmp/Python-3.10.4.tgz
-WORKDIR /tmp
-RUN tar xzf Python-3.10.4.tgz
-WORKDIR /tmp/Python-3.10.4
-RUN ./configure --enable-optimizations --with-openssl=/usr/local/openssl11
-RUN yum install make -y
-RUN make altinstall
-RUN yum install which -y
-WORKDIR /tmp
-RUN rm -r Python-3.10.4.tgz
-RUN yum -y install epel-release
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py | python3.10
-RUN python3.10 -m pip install --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host pypi.org --upgrade pip
-
-#
-# Create a link for python3
-#
-RUN ln -sf /usr/local/bin/python3.10  /usr/bin/python3
-RUN ln -sf /usr/bin/python3  /usr/bin/python
-
-RUN ln -sf /usr/local/bin/pip3.10  /usr/bin/pip3
-RUN ln -sf /usr/bin/pip3  /usr/bin/pip
-
-#
-# Install GEOS - needed for cartopy
-#
-WORKDIR /tmp
-RUN wget http://download.osgeo.org/geos/geos-3.7.2.tar.bz2
-RUN tar xjf geos-3.7.2.tar.bz2
-WORKDIR /tmp/geos-3.7.2
-RUN ./configure --enable-php; make clean ; make
-RUN make install
-RUN ldconfig
-WORKDIR /tmp
-RUN rm -r geos-3.7.2.tar.bz2
-
-#
-# Install Python packages
-#
-RUN pip install cartopy \
- && pip install eofs \
- && pip install imutils==0.5.4 \
- && pip install imageio==2.19.2 \
- && pip install lxml==4.9.1 \
- && pip install matplotlib==3.5.2 \
- && pip install netcdf4==1.6.2 \
- && pip install numpy==1.22.0 \
- && pip install pytest==7.1.2 \
- && pip install metpy==1.3.1 \
- && pip install pyyaml==6.0 \
- && pip install scikit-image==0.19.3 \
- && pip install scikit-learn \
- && pip install scipy==1.11.1 \
- && pip install xarray==2022.3.0 \
- && pip install PyMySQL==1.0.2 \
- && pip install pint==0.19.2 \
- && pip install plotly==5.9.0 \
- && pip install kaleido==0.2.1 \
- && pip install attrs==22.1.0 \
- && pip install exceptiongroup==1.0.4 \
- && pip install iniconfig==1.1.1 \
- && pip install packaging==22.0 \
- && pip install pluggy==1.0.0 \
- && pip install pytz==2022.6 \
- && pip install setuptools==65.5.1 \
- && pip install six==1.16.0 \
- && pip install tomli==2.0.1 \
- && pip install wheel==0.38.1 \
- && pip install python-dateutil==2.8.2 \
- && pip install opencv-python \
- && pip install pandas==1.5.2
-
-#
-# Set env vars
-#
-ENV PYTHONPATH "${PYTHONPATH}:/METviewer-python/METcalcpy/:/METviewer-python/METplotpy/"
-ENV METPLOTPY_BASE "/METviewer-python/METplotpy/"
-
-#
-# Remove unneeded scripts
-#
-RUN rm /METviewer/bin/auto_test.sh \
- && rm /METviewer/bin/mv_test.sh \
- && rm /METviewer/bin/nightly_test.sh \
- && rm /METviewer/bin/prep_dist.sh \
- && rm /METviewer/bin/mv_compare.sh \
- && rm -r /METviewer/test
-
-#
-# Change permissions of the scripts
-#
-RUN chmod 755 /METviewer/bin/mv_batch.sh \
- && chmod 755 /METviewer/bin/mv_load.sh \
- && chmod 755 /METviewer/bin/mv_prune.sh \
- && chmod 755 /METviewer/bin/mv_scorecard.sh
-
-#
-# Database install
-#
+RUN cd /METviewer \
+ && internal/scripts/docker/build_metviewer_docker.sh
 
 #
 # Fix permissions to allow for running on openshift

--- a/internal/scripts/docker/Dockerfile.copy
+++ b/internal/scripts/docker/Dockerfile.copy
@@ -1,4 +1,4 @@
-ARG MET_BASE_REPO=met-base
+ARG MET_BASE_REPO=met-base-metviewer
 ARG MET_BASE_TAG=v3.2
 
 FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
@@ -33,11 +33,6 @@ RUN echo "Build Argument METVIEWER_GIT_NAME=${METVIEWER_GIT_NAME}" \
  && echo "Build Argument METPLOTPY_GIT_NAME=${METPLOTPY_GIT_NAME}" \
  && echo "Build Argument METCALCPY_GIT_NAME=${METCALCPY_GIT_NAME}" \
  && echo "Build Argument METDATAIO_GIT_NAME=${METDATAIO_GIT_NAME}"
-
-#
-# Expose METviewer port
-#
-EXPOSE 8080
 
 #
 # Set env vars

--- a/internal/scripts/docker/Dockerfile.copy
+++ b/internal/scripts/docker/Dockerfile.copy
@@ -1,10 +1,13 @@
-FROM centos:7
+ARG MET_BASE_REPO=met-base
+ARG MET_BASE_TAG=v3.2
 
-MAINTAINER Tatiana Burek <tatiana@ucar.edu>
+FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
+MAINTAINER John Halley Gotway <johnhg@ucar.edu>
 
 #
-# This Dockerfile checks out the METviewer dependencies from GitHub and builds the local METviewer repository.
-# Use the develop branches for dependencies by default but override with "--build-arg".
+# This Dockerfile checks out the METviewer dependencies from GitHub and builds
+# the local METviewer repository. Use the develop branches for dependencies
+# by default but override with "--build-arg".
 #
 
 ARG SOURCE_BRANCH
@@ -13,7 +16,7 @@ ARG METCALCPY_GIT_NAME=develop
 ARG METDATAIO_GIT_NAME=develop
 
 #
-# SOURCE_BRANCH is required to define the branch of the local METviewer repository.
+# SOURCE_BRANCH is required to define the local METviewer repository branch name.
 #
 RUN if [ "x${SOURCE_BRANCH}" = "x" ]; then \
       echo "ERROR: SOURCE_BRANCH undefined! Rebuild with \"--build-arg SOURCE_BRANCH={branch name}\""; \
@@ -21,6 +24,7 @@ RUN if [ "x${SOURCE_BRANCH}" = "x" ]; then \
     else \
       echo "Build Argument SOURCE_BRANCH=${SOURCE_BRANCH}"; \
     fi
+
 ENV METVIEWER_GIT_NAME ${SOURCE_BRANCH}
 
 RUN echo "Build Argument METVIEWER_GIT_NAME=${METVIEWER_GIT_NAME}" \
@@ -39,35 +43,20 @@ ENV METDATAIO_GIT_URL https://github.com/dtcenter/METdataio
 #
 # Constants
 #
-ENV TOMCAT_MINOR_VERSION 5.61
-ENV TOMCAT_MAJOR_VERSION 8
+ENV TOMCAT_MAJOR_VERSION 9
+ENV TOMCAT_MINOR_VERSION 0.89
 ENV TOMCAT_VERSION ${TOMCAT_MAJOR_VERSION}.${TOMCAT_MINOR_VERSION}
 
 #
-# Install system updates
+# Update the OS, as needed
 #
-RUN yum -y update \
- && yum -y install epel-release \
- && yum -y install 'dnf-command(config-manager)' \
- && yum-config-manager --enable PowerTools
+RUN apt update \
+ && apt -y upgrade
 
 #
 # Install required packages
 #
-RUN yum -y install wget tar git ant java R mysql ksh \
- && rm -rf /var/cache/yum/* \
- && yum clean all
-
-#
-# Install gsl-2.5 on which the R gsl package depends.
-# The centos7 gal package is too old (version 1.5).
-#
-RUN echo "Compiling gsl-2.5" \
- && curl -SL http://gnu.askapache.com/gsl/gsl-2.5.tar.gz | tar zxC /lib \
- && cd /lib/gsl-2.5 \
- && ./configure --prefix=/usr --libdir=/usr/lib64 >& configure.log \
- && make >& make.log \
- && make install >& make_install.log
+RUN apt -y install ant openjdk-17-jdk r-base mariadb-server ksh
 
 #
 # Setup default cran repo
@@ -113,7 +102,7 @@ WORKDIR /METviewer-python/
 RUN git clone --branch ${METDATAIO_GIT_NAME} ${METDATAIO_GIT_URL}
 
 #
-# Copy in the local METviewer repository
+# Install METviewer by copying in the local METviewer repository.
 #
 RUN echo "Copying METviewer into /METviewer" \
  && mkdir -p /METviewer
@@ -175,36 +164,13 @@ RUN echo "Configuring and building METviewer" \
  && mv mv_prune.sh-DOCKER mv_prune.sh
 
 #
-# Install Python 3.10.4
-#
-RUN yum install gcc openssl11 openssl11-devel libreadline-gplv2-dev libncursesw5-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev openssl-devel libssl-dev bzip2-devel libffi-devel zlib-devel libproj-dev proj-data proj-bin libgeos-dev bzip2 -y
-RUN mkdir /usr/local/openssl11
-WORKDIR /usr/local/openssl11
-RUN ln -s /usr/lib64/openssl11 lib
-RUN ln -s /usr/include/openssl11 include
-
-RUN curl https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz --output /tmp/Python-3.10.4.tgz
-WORKDIR /tmp
-RUN tar xzf Python-3.10.4.tgz
-WORKDIR /tmp/Python-3.10.4
-RUN ./configure --enable-optimizations --with-openssl=/usr/local/openssl11
-RUN yum install make -y
-RUN make altinstall
-RUN yum install which -y
-WORKDIR /tmp
-RUN rm -r Python-3.10.4.tgz
-RUN yum -y install epel-release
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py | python3.10
-RUN python3.10 -m pip install --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host pypi.org --upgrade pip
-
-#
 # Create a link for python3
 #
-RUN ln -sf /usr/local/bin/python3.10  /usr/bin/python3
-RUN ln -sf /usr/bin/python3  /usr/bin/python
+RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python3
+RUN ln -sf /usr/bin/python3 /usr/bin/python
 
-RUN ln -sf /usr/local/bin/pip3.10  /usr/bin/pip3
-RUN ln -sf /usr/bin/pip3  /usr/bin/pip
+RUN ln -sf /usr/local/bin/pip3.10 /usr/bin/pip3
+RUN ln -sf /usr/bin/pip3 /usr/bin/pip
 
 #
 # Install GEOS - needed for cartopy
@@ -269,7 +235,7 @@ RUN rm /METviewer/bin/auto_test.sh \
  && rm /METviewer/bin/nightly_test.sh \
  && rm /METviewer/bin/prep_dist.sh \
  && rm /METviewer/bin/mv_compare.sh \
- && rm -r  /METviewer/test
+ && rm -r /METviewer/test
 
 #
 # Change permissions of the scripts

--- a/internal/scripts/docker/Dockerfile.copy
+++ b/internal/scripts/docker/Dockerfile.copy
@@ -41,6 +41,11 @@ ENV PYTHONPATH "${PYTHONPATH}:/METviewer-python/METcalcpy/:/METviewer-python/MET
 ENV METPLOTPY_BASE "/METviewer-python/METplotpy/"
 
 #
+# Update the OS, as needed
+#
+RUN apt update && apt -y upgrade
+
+#
 # Copy in the local METviewer repository
 #
 RUN echo "Copying METviewer into /METviewer" \
@@ -52,6 +57,24 @@ RUN if [ ! -e "/METviewer/build.xml" ]; then \
     echo "ERROR: docker build must be run from the top-level METviewer directory"; \
     exit 1; \
   fi
+
+#
+# Configure METviewer
+#
+RUN echo "Configuring METviewer" \
+ && cd /METviewer \
+ && cat webapp/metviewer/WEB-INF/classes/build.properties | \
+    sed -r 's%db.host=.*%db.host=mysql_mv%g' | \
+    sed -r 's%db.user=.*%db.user=root%g' | \
+    sed -r 's%db.password=.*%db.password=mvuser%g' | \
+    sed -r 's%db.management.system=.*%db.management.system=mysql%g' | \
+    sed -r 's%output.dir=.*%output.dir=/opt/tomcat/webapps/metviewer_output/%g' | \
+    sed -r 's%webapps.dir=.*%webapps.dir=/opt/tomcat/webapps/metviewer/%g' | \
+    sed -r 's%url.output=.*%url.output=http://localhost:8080/metviewer_output/%g' | \
+    sed -r 's%python.env=.*%python.env=/usr/%g' | \
+    sed -r 's%metcalcpy.home=.*%metcalcpy.home=/METviewer-python/METcalcpy/%g' | \
+    sed -r 's%metplotpy.home=.*%metplotpy.home=/METviewer-python/METplotpy/%g' \
+    > build.properties
 
 #
 # Run the build script

--- a/internal/scripts/docker/Dockerfile.copy
+++ b/internal/scripts/docker/Dockerfile.copy
@@ -11,9 +11,9 @@ MAINTAINER John Halley Gotway <johnhg@ucar.edu>
 #
 
 ARG SOURCE_BRANCH
-ARG METPLOTPY_GIT_NAME=develop
-ARG METCALCPY_GIT_NAME=develop
-ARG METDATAIO_GIT_NAME=develop
+ENV METPLOTPY_GIT_NAME=develop
+ENV METCALCPY_GIT_NAME=develop
+ENV METDATAIO_GIT_NAME=develop
 
 #
 # SOURCE_BRANCH is required to define the local METviewer repository branch name.
@@ -25,7 +25,9 @@ RUN if [ "x${SOURCE_BRANCH}" = "x" ]; then \
       echo "Build Argument SOURCE_BRANCH=${SOURCE_BRANCH}"; \
     fi
 
+ENV METVIEWER_GIT_URL https://github.com/dtcenter/METviewer
 ENV METVIEWER_GIT_NAME ${SOURCE_BRANCH}
+ENV CATALINA_HOME /opt/tomcat
 
 RUN echo "Build Argument METVIEWER_GIT_NAME=${METVIEWER_GIT_NAME}" \
  && echo "Build Argument METPLOTPY_GIT_NAME=${METPLOTPY_GIT_NAME}" \
@@ -33,76 +35,18 @@ RUN echo "Build Argument METVIEWER_GIT_NAME=${METVIEWER_GIT_NAME}" \
  && echo "Build Argument METDATAIO_GIT_NAME=${METDATAIO_GIT_NAME}"
 
 #
-# Repository URLs
+# Expose METviewer port
 #
-ENV METVIEWER_GIT_URL https://github.com/dtcenter/METviewer
-ENV METPLOTPY_GIT_URL https://github.com/dtcenter/METplotpy
-ENV METCALCPY_GIT_URL https://github.com/dtcenter/METcalcpy
-ENV METDATAIO_GIT_URL https://github.com/dtcenter/METdataio
-
-#
-# Constants
-#
-ENV TOMCAT_MAJOR_VERSION 9
-ENV TOMCAT_MINOR_VERSION 0.89
-ENV TOMCAT_VERSION ${TOMCAT_MAJOR_VERSION}.${TOMCAT_MINOR_VERSION}
-
-#
-# Update the OS, as needed
-#
-RUN apt update \
- && apt -y upgrade
-
-#
-# Install required packages
-#
-RUN apt -y install ant openjdk-17-jdk r-base mariadb-server ksh
-
-#
-# Setup default cran repo
-#
-RUN echo "r <- getOption('repos'); r['CRAN'] <- 'http://cran.us.r-project.org'; options(repos = r);" > ~/.Rprofile
-
-#
-# Install required R packages
-#
-RUN Rscript -e "install.packages('boot')" \
- && Rscript -e "install.packages('plotrix')" \
- && Rscript -e "install.packages('gsl')" \
- && Rscript -e "install.packages('data.table')" \
- && Rscript -e "install.packages('verification')"
-
-#
-# Install Tomcat
-#
-ENV CATALINA_HOME /opt/tomcat
-
-RUN wget https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz \
- && tar -xvf apache-tomcat-${TOMCAT_VERSION}.tar.gz \
- && rm apache-tomcat*.tar.gz \
- && mv apache-tomcat* ${CATALINA_HOME} \
- && chmod +x ${CATALINA_HOME}/bin/*sh
-
 EXPOSE 8080
 
 #
-# Install METplus python components
+# Set env vars
 #
-RUN mkdir /METviewer-python \
- && echo "Checking out METcalcpy ${METCALCPY_GIT_NAME} from ${METCALCPY_GIT_URL}"
-WORKDIR /METviewer-python/
-RUN git clone --branch ${METCALCPY_GIT_NAME} ${METCALCPY_GIT_URL}
-
-RUN echo "Checking out METplotpy ${METPLOTPY_GIT_NAME} from ${METPLOTPY_GIT_URL}"
-WORKDIR /METviewer-python/
-RUN git clone --branch ${METPLOTPY_GIT_NAME} ${METPLOTPY_GIT_URL}
-
-RUN echo "Checking out METdataio ${METDATAIO_GIT_NAME} from ${METDATAIO_GIT_URL}"
-WORKDIR /METviewer-python/
-RUN git clone --branch ${METDATAIO_GIT_NAME} ${METDATAIO_GIT_URL}
+ENV PYTHONPATH "${PYTHONPATH}:/METviewer-python/METcalcpy/:/METviewer-python/METplotpy/"
+ENV METPLOTPY_BASE "/METviewer-python/METplotpy/"
 
 #
-# Install METviewer by copying in the local METviewer repository.
+# Copy in the local METviewer repository
 #
 RUN echo "Copying METviewer into /METviewer" \
  && mkdir -p /METviewer
@@ -114,137 +58,10 @@ RUN if [ ! -e "/METviewer/build.xml" ]; then \
     exit 1; \
   fi
 
-RUN echo "Configuring and building METviewer" \
- && cd /METviewer \
- && cat webapp/metviewer/WEB-INF/classes/build.properties | \
-    sed -r 's%db.host=.*%db.host=mysql_mv%g' | \
-    sed -r 's%db.user=.*%db.user=root%g' | \
-    sed -r 's%db.password=.*%db.password=mvuser%g' | \
-    sed -r 's%db.management.system=.*%db.management.system=mysql%g' | \
-    sed -r 's%output.dir=.*%output.dir=/opt/tomcat/webapps/metviewer_output/%g' | \
-    sed -r 's%webapps.dir=.*%webapps.dir=/opt/tomcat/webapps/metviewer/%g' | \
-    sed -r 's%url.output=.*%url.output=http://localhost:8080/metviewer_output/%g' | \
-    sed -r 's%python.env=.*%python.env=/usr/%g' | \
-    sed -r 's%metcalcpy.home=.*%metcalcpy.home=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%metplotpy.home=.*%metplotpy.home=/METviewer-python/METplotpy/%g' \
-    > build.properties \
- && ant -Dbuild.properties.file=./build.properties \
-        -Ddb.management.system=mysql \
-        -Dmetcalcpy.path=/METviewer-python/METcalcpy/ \
-        -Dmetplotpy.path=/METviewer-python/METplotpy/ \
-        -Dpython.env.path=/usr/ war \
- && mv /METviewer/dist/*.war ${CATALINA_HOME}/webapps \
- && echo "Configuring METviewer scripts" \
- && cd /METviewer/bin \
- && cat mv_batch.sh | \
-    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
-    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
-    >  mv_batch.sh-DOCKER \
- && mv mv_batch.sh-DOCKER mv_batch.sh \
- && cat mv_load.sh | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g'  | \
-    sed -r 's%METDATAIO_HOME=.*%METDATAIO_HOME=/METviewer-python/METdataio/%g' \
-    >  mv_load.sh-DOCKER \
- && mv mv_load.sh-DOCKER mv_load.sh \
- && cat mv_scorecard.sh | \
-    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
-    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
-    >  mv_scorecard.sh-DOCKER \
- && mv mv_scorecard.sh-DOCKER mv_scorecard.sh \
- && cat mv_prune.sh | \
-    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
-    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
-    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
-    >  mv_prune.sh-DOCKER \
- && mv mv_prune.sh-DOCKER mv_prune.sh
+#
+# Run build script
+#
+RUN internal/scripts/docker/build_metviewer_docker.sh
 
-#
-# Create a link for python3
-#
-RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python3
-RUN ln -sf /usr/bin/python3 /usr/bin/python
-
-RUN ln -sf /usr/local/bin/pip3.10 /usr/bin/pip3
-RUN ln -sf /usr/bin/pip3 /usr/bin/pip
-
-#
-# Install GEOS - needed for cartopy
-#
-WORKDIR /tmp
-RUN wget http://download.osgeo.org/geos/geos-3.7.2.tar.bz2
-RUN tar xjf geos-3.7.2.tar.bz2
-WORKDIR /tmp/geos-3.7.2
-RUN ./configure --enable-php; make clean ; make
-RUN make install
-RUN ldconfig
-WORKDIR /tmp
-RUN rm -r geos-3.7.2.tar.bz2
-
-#
-# Install Python packages
-#
-RUN pip install cartopy \
- && pip install eofs \
- && pip install imutils==0.5.4 \
- && pip install imageio==2.19.2 \
- && pip install lxml==4.9.1 \
- && pip install matplotlib==3.5.2 \
- && pip install netcdf4==1.6.2 \
- && pip install numpy==1.22.0 \
- && pip install pytest==7.1.2 \
- && pip install metpy==1.3.1 \
- && pip install pyyaml==6.0 \
- && pip install scikit-image==0.19.3 \
- && pip install scikit-learn \
- && pip install scipy==1.11.1 \
- && pip install xarray==2022.3.0 \
- && pip install PyMySQL==1.0.2 \
- && pip install pint==0.19.2 \
- && pip install plotly==5.9.0 \
- && pip install kaleido==0.2.1 \
- && pip install attrs==22.1.0 \
- && pip install exceptiongroup==1.0.4 \
- && pip install iniconfig==1.1.1 \
- && pip install packaging==22.0 \
- && pip install pluggy==1.0.0 \
- && pip install pytz==2022.6 \
- && pip install setuptools==65.5.1 \
- && pip install six==1.16.0 \
- && pip install tomli==2.0.1 \
- && pip install wheel==0.38.1 \
- && pip install python-dateutil==2.8.2 \
- && pip install opencv-python \
- && pip install pandas==1.5.2
-
-#
-# Set env vars
-#
-ENV PYTHONPATH "${PYTHONPATH}:/METviewer-python/METcalcpy/:/METviewer-python/METplotpy/"
-ENV METPLOTPY_BASE "/METviewer-python/METplotpy/"
-
-#
-# Remove unneeded scripts
-#
-RUN rm /METviewer/bin/auto_test.sh \
- && rm /METviewer/bin/mv_test.sh \
- && rm /METviewer/bin/nightly_test.sh \
- && rm /METviewer/bin/prep_dist.sh \
- && rm /METviewer/bin/mv_compare.sh \
- && rm -r /METviewer/test
-
-#
-# Change permissions of the scripts
-#
-RUN chmod 755 /METviewer/bin/mv_batch.sh \
- && chmod 755 /METviewer/bin/mv_load.sh \
- && chmod 755 /METviewer/bin/mv_prune.sh \
- && chmod 755 /METviewer/bin/mv_scorecard.sh
-
-ENTRYPOINT ${CATALINA_HOME}/bin/startup.sh  && /bin/bash
+ENTRYPOINT ${CATALINA_HOME}/bin/startup.sh && /bin/bash
 CMD ["true"]
-

--- a/internal/scripts/docker/Dockerfile.copy
+++ b/internal/scripts/docker/Dockerfile.copy
@@ -61,7 +61,8 @@ RUN if [ ! -e "/METviewer/build.xml" ]; then \
 #
 # Run build script
 #
-RUN internal/scripts/docker/build_metviewer_docker.sh
+RUN cd /METviewer \
+ && internal/scripts/docker/build_metviewer_docker.sh
 
 ENTRYPOINT ${CATALINA_HOME}/bin/startup.sh && /bin/bash
 CMD ["true"]

--- a/internal/scripts/docker/Dockerfile.copy
+++ b/internal/scripts/docker/Dockerfile.copy
@@ -59,7 +59,7 @@ RUN if [ ! -e "/METviewer/build.xml" ]; then \
   fi
 
 #
-# Run build script
+# Run the build script
 #
 RUN cd /METviewer \
  && internal/scripts/docker/build_metviewer_docker.sh

--- a/internal/scripts/docker/build_metviewer_docker.sh
+++ b/internal/scripts/docker/build_metviewer_docker.sh
@@ -136,7 +136,7 @@ cd /tmp
 wget http://download.osgeo.org/geos/geos-3.7.2.tar.bz2
 tar xjf geos-3.7.2.tar.bz2
 cd /tmp/geos-3.7.2
-./configure --enable-php; make clean ; make
+./configure ; make clean ; make
 make install
 ldconfig
 cd /tmp

--- a/internal/scripts/docker/build_metviewer_docker.sh
+++ b/internal/scripts/docker/build_metviewer_docker.sh
@@ -7,11 +7,6 @@ export METPLOTPY_GIT_URL=https://github.com/dtcenter/METplotpy
 export METCALCPY_GIT_URL=https://github.com/dtcenter/METcalcpy
 export METDATAIO_GIT_URL=https://github.com/dtcenter/METdataio
 
-# Software constants
-export TOMCAT_MAJOR_VERSION=9
-export TOMCAT_MINOR_VERSION=0.89
-export TOMCAT_VERSION=${TOMCAT_MAJOR_VERSION}.${TOMCAT_MINOR_VERSION}
-
 # Check for required environment variables
 if [ -z ${CATALINA_HOME+x} ]; then
   echo "ERROR: \${CATALINA_HOME} is required!"
@@ -31,28 +26,7 @@ if [ -z ${METDATAIO_GIT_NAME+x} ]; then
 fi
 
 # Update the OS, as needed
-apt update
-apt -y upgrade
-
-# Install required packages
-apt -y install ant openjdk-17-jdk r-base mariadb-server ksh
-
-# Setup default cran repo
-echo "r <- getOption('repos'); r['CRAN'] <- 'http://cran.us.r-project.org'; options(repos = r);" > ~/.Rprofile
-
-# Install required R packages
-Rscript -e "install.packages('boot')"
-Rscript -e "install.packages('plotrix')"
-Rscript -e "install.packages('gsl')"
-Rscript -e "install.packages('data.table')"
-Rscript -e "install.packages('verification')"
-
-# Install Tomcat
-wget https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz
-tar -xvf apache-tomcat-${TOMCAT_VERSION}.tar.gz
-rm apache-tomcat*.tar.gz
-mv apache-tomcat* ${CATALINA_HOME}
-chmod +x ${CATALINA_HOME}/bin/*sh
+apt update && apt -y upgrade
 
 # Install METplus python components
 mkdir /METviewer-python
@@ -123,58 +97,6 @@ cat mv_prune.sh | \
     sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
     >  mv_prune.sh-DOCKER
 mv mv_prune.sh-DOCKER mv_prune.sh
-
-# Create links for python3
-ln -sf /usr/local/bin/python3.10 /usr/bin/python3
-ln -sf /usr/bin/python3 /usr/bin/python
-
-ln -sf /usr/local/bin/pip3.10 /usr/bin/pip3
-ln -sf /usr/bin/pip3 /usr/bin/pip
-
-# Install GEOS - needed for cartopy
-cd /tmp
-wget http://download.osgeo.org/geos/geos-3.7.2.tar.bz2
-tar xjf geos-3.7.2.tar.bz2
-cd /tmp/geos-3.7.2
-./configure ; make clean ; make
-make install
-ldconfig
-cd /tmp
-rm -r geos-3.7.2.tar.bz2
-
-# Install Python packages
-pip install cartopy && \
-pip install eofs && \
-pip install imutils==0.5.4 && \
-pip install imageio==2.19.2 && \
-pip install lxml==4.9.1 && \
-pip install matplotlib==3.5.2 && \
-pip install netcdf4==1.6.2 && \
-pip install numpy==1.22.0 && \
-pip install pytest==7.1.2 && \
-pip install metpy==1.3.1 && \
-pip install pyyaml==6.0 && \
-pip install scikit-image==0.19.3 && \
-pip install scikit-learn && \
-pip install scipy==1.11.1 && \
-pip install xarray==2022.3.0 && \
-pip install PyMySQL==1.0.2 && \
-pip install pint==0.19.2 && \
-pip install plotly==5.9.0 && \
-pip install kaleido==0.2.1 && \
-pip install attrs==22.1.0 && \
-pip install exceptiongroup==1.0.4 && \
-pip install iniconfig==1.1.1 && \
-pip install packaging==22.0 && \
-pip install pluggy==1.0.0 && \
-pip install pytz==2022.6 && \
-pip install setuptools==65.5.1 && \
-pip install six==1.16.0 && \
-pip install tomli==2.0.1 && \
-pip install wheel==0.38.1 && \
-pip install python-dateutil==2.8.2 && \
-pip install opencv-python && \
-pip install pandas==1.5.2
 
 # Remove unneeded scripts
 rm /METviewer/bin/auto_test.sh \

--- a/internal/scripts/docker/build_metviewer_docker.sh
+++ b/internal/scripts/docker/build_metviewer_docker.sh
@@ -50,7 +50,7 @@ ant -Dbuild.properties.file=./build.properties \
     -Ddb.management.system=mysql \
     -Dmetcalcpy.path=/METviewer-python/METcalcpy/ \
     -Dmetplotpy.path=/METviewer-python/METplotpy/ \
-    -Dpython.env.path=/usr/ war \
+    -Dpython.env.path=/usr/ war
 mv /METviewer/dist/*.war ${CATALINA_HOME}/webapps
 
 echo "Configuring METviewer scripts"

--- a/internal/scripts/docker/build_metviewer_docker.sh
+++ b/internal/scripts/docker/build_metviewer_docker.sh
@@ -41,28 +41,16 @@ git clone --branch ${METPLOTPY_GIT_NAME} ${METPLOTPY_GIT_URL}
 echo "Checking out METdataio ${METDATAIO_GIT_NAME} from ${METDATAIO_GIT_URL}"
 git clone --branch ${METDATAIO_GIT_NAME} ${METDATAIO_GIT_URL}
 
-# Install METviewer
-echo "Configuring and building METviewer"
+# Build METviewer
+
+echo "Building METviewer"
 cd /METviewer
-cat webapp/metviewer/WEB-INF/classes/build.properties | \
-    sed -r 's%db.host=.*%db.host=mysql_mv%g' | \
-    sed -r 's%db.user=.*%db.user=root%g' | \
-    sed -r 's%db.password=.*%db.password=mvuser%g' | \
-    sed -r 's%db.management.system=.*%db.management.system=mysql%g' | \
-    sed -r 's%output.dir=.*%output.dir=/opt/tomcat/webapps/metviewer_output/%g' | \
-    sed -r 's%webapps.dir=.*%webapps.dir=/opt/tomcat/webapps/metviewer/%g' | \
-    sed -r 's%url.output=.*%url.output=http://localhost:8080/metviewer_output/%g' | \
-    sed -r 's%python.env=.*%python.env=/usr/%g' | \
-    sed -r 's%metcalcpy.home=.*%metcalcpy.home=/METviewer-python/METcalcpy/%g' | \
-    sed -r 's%metplotpy.home=.*%metplotpy.home=/METviewer-python/METplotpy/%g' \
-    > build.properties
 
 ant -Dbuild.properties.file=./build.properties \
     -Ddb.management.system=mysql \
     -Dmetcalcpy.path=/METviewer-python/METcalcpy/ \
     -Dmetplotpy.path=/METviewer-python/METplotpy/ \
     -Dpython.env.path=/usr/ war \
-
 mv /METviewer/dist/*.war ${CATALINA_HOME}/webapps
 
 echo "Configuring METviewer scripts"

--- a/internal/scripts/docker/build_metviewer_docker.sh
+++ b/internal/scripts/docker/build_metviewer_docker.sh
@@ -1,0 +1,188 @@
+#! /bin/bash
+
+echo "Running script to build METviewer and its dependencies in Docker"
+
+# GitHub constants
+export METPLOTPY_GIT_URL=https://github.com/dtcenter/METplotpy
+export METCALCPY_GIT_URL=https://github.com/dtcenter/METcalcpy
+export METDATAIO_GIT_URL=https://github.com/dtcenter/METdataio
+
+# Software constants
+export TOMCAT_MAJOR_VERSION=9
+export TOMCAT_MINOR_VERSION=0.89
+export TOMCAT_VERSION=${TOMCAT_MAJOR_VERSION}.${TOMCAT_MINOR_VERSION}
+
+# Check for required environment variables
+if [ -z ${CATALINA_HOME+x} ]; then
+  echo "ERROR: \${CATALINA_HOME} is required!"
+  exit 1
+fi
+if [ -z ${METPLOTPY_GIT_NAME+x} ]; then
+  echo "ERROR: \${METPLOTPY_GIT_NAME} is required!"
+  exit 1
+fi
+if [ -z ${METCALCPY_GIT_NAME+x} ]; then
+  echo "ERROR: \${METCALCPY_GIT_NAME} is required!"
+  exit 1
+fi
+if [ -z ${METDATAIO_GIT_NAME+x} ]; then
+  echo "ERROR: \${METDATAIO_GIT_NAME} is required!"
+  exit 1
+fi
+
+# Update the OS, as needed
+apt update
+apt -y upgrade
+
+# Install required packages
+apt -y install ant openjdk-17-jdk r-base mariadb-server ksh
+
+# Setup default cran repo
+echo "r <- getOption('repos'); r['CRAN'] <- 'http://cran.us.r-project.org'; options(repos = r);" > ~/.Rprofile
+
+# Install required R packages
+Rscript -e "install.packages('boot')"
+Rscript -e "install.packages('plotrix')"
+Rscript -e "install.packages('gsl')"
+Rscript -e "install.packages('data.table')"
+Rscript -e "install.packages('verification')"
+
+# Install Tomcat
+wget https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz
+tar -xvf apache-tomcat-${TOMCAT_VERSION}.tar.gz
+rm apache-tomcat*.tar.gz
+mv apache-tomcat* ${CATALINA_HOME}
+chmod +x ${CATALINA_HOME}/bin/*sh
+
+# Install METplus python components
+mkdir /METviewer-python
+cd /METviewer-python
+
+echo "Checking out METcalcpy ${METCALCPY_GIT_NAME} from ${METCALCPY_GIT_URL}"
+git clone --branch ${METCALCPY_GIT_NAME} ${METCALCPY_GIT_URL}
+
+echo "Checking out METplotpy ${METPLOTPY_GIT_NAME} from ${METPLOTPY_GIT_URL}"
+git clone --branch ${METPLOTPY_GIT_NAME} ${METPLOTPY_GIT_URL}
+
+echo "Checking out METdataio ${METDATAIO_GIT_NAME} from ${METDATAIO_GIT_URL}"
+git clone --branch ${METDATAIO_GIT_NAME} ${METDATAIO_GIT_URL}
+
+# Install METviewer
+echo "Configuring and building METviewer"
+cd /METviewer
+cat webapp/metviewer/WEB-INF/classes/build.properties | \
+    sed -r 's%db.host=.*%db.host=mysql_mv%g' | \
+    sed -r 's%db.user=.*%db.user=root%g' | \
+    sed -r 's%db.password=.*%db.password=mvuser%g' | \
+    sed -r 's%db.management.system=.*%db.management.system=mysql%g' | \
+    sed -r 's%output.dir=.*%output.dir=/opt/tomcat/webapps/metviewer_output/%g' | \
+    sed -r 's%webapps.dir=.*%webapps.dir=/opt/tomcat/webapps/metviewer/%g' | \
+    sed -r 's%url.output=.*%url.output=http://localhost:8080/metviewer_output/%g' | \
+    sed -r 's%python.env=.*%python.env=/usr/%g' | \
+    sed -r 's%metcalcpy.home=.*%metcalcpy.home=/METviewer-python/METcalcpy/%g' | \
+    sed -r 's%metplotpy.home=.*%metplotpy.home=/METviewer-python/METplotpy/%g' \
+    > build.properties
+
+ant -Dbuild.properties.file=./build.properties \
+    -Ddb.management.system=mysql \
+    -Dmetcalcpy.path=/METviewer-python/METcalcpy/ \
+    -Dmetplotpy.path=/METviewer-python/METplotpy/ \
+    -Dpython.env.path=/usr/ war \
+
+mv /METviewer/dist/*.war ${CATALINA_HOME}/webapps
+
+echo "Configuring METviewer scripts"
+cd /METviewer/bin
+
+cat mv_batch.sh | \
+    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
+    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
+    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
+    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
+    >  mv_batch.sh-DOCKER
+mv mv_batch.sh-DOCKER mv_batch.sh
+
+cat mv_load.sh | \
+    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g'  | \
+    sed -r 's%METDATAIO_HOME=.*%METDATAIO_HOME=/METviewer-python/METdataio/%g' \
+    > mv_load.sh-DOCKER
+mv mv_load.sh-DOCKER mv_load.sh \
+
+cat mv_scorecard.sh | \
+    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
+    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
+    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
+    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
+    >  mv_scorecard.sh-DOCKER
+mv mv_scorecard.sh-DOCKER mv_scorecard.sh
+
+cat mv_prune.sh | \
+    sed -r 's%JAVA=.*%JAVA=java\nMV_HOME=/METviewer%g' | \
+    sed -r 's%PYTHON_ENV=.*%PYTHON_ENV=/usr%g' | \
+    sed -r 's%METCALCPY_HOME=.*%METCALCPY_HOME=/METviewer-python/METcalcpy/%g' | \
+    sed -r 's%METPLOTPY_HOME=.*%METPLOTPY_HOME=/METviewer-python/METplotpy/%g' \
+    >  mv_prune.sh-DOCKER
+mv mv_prune.sh-DOCKER mv_prune.sh
+
+# Create links for python3
+ln -sf /usr/local/bin/python3.10 /usr/bin/python3
+ln -sf /usr/bin/python3 /usr/bin/python
+
+ln -sf /usr/local/bin/pip3.10 /usr/bin/pip3
+ln -sf /usr/bin/pip3 /usr/bin/pip
+
+# Install GEOS - needed for cartopy
+cd /tmp
+wget http://download.osgeo.org/geos/geos-3.7.2.tar.bz2
+tar xjf geos-3.7.2.tar.bz2
+cd /tmp/geos-3.7.2
+./configure --enable-php; make clean ; make
+make install
+ldconfig
+cd /tmp
+rm -r geos-3.7.2.tar.bz2
+
+# Install Python packages
+pip install cartopy && \
+pip install eofs && \
+pip install imutils==0.5.4 && \
+pip install imageio==2.19.2 && \
+pip install lxml==4.9.1 && \
+pip install matplotlib==3.5.2 && \
+pip install netcdf4==1.6.2 && \
+pip install numpy==1.22.0 && \
+pip install pytest==7.1.2 && \
+pip install metpy==1.3.1 && \
+pip install pyyaml==6.0 && \
+pip install scikit-image==0.19.3 && \
+pip install scikit-learn && \
+pip install scipy==1.11.1 && \
+pip install xarray==2022.3.0 && \
+pip install PyMySQL==1.0.2 && \
+pip install pint==0.19.2 && \
+pip install plotly==5.9.0 && \
+pip install kaleido==0.2.1 && \
+pip install attrs==22.1.0 && \
+pip install exceptiongroup==1.0.4 && \
+pip install iniconfig==1.1.1 && \
+pip install packaging==22.0 && \
+pip install pluggy==1.0.0 && \
+pip install pytz==2022.6 && \
+pip install setuptools==65.5.1 && \
+pip install six==1.16.0 && \
+pip install tomli==2.0.1 && \
+pip install wheel==0.38.1 && \
+pip install python-dateutil==2.8.2 && \
+pip install opencv-python && \
+pip install pandas==1.5.2
+
+# Remove unneeded scripts
+rm /METviewer/bin/auto_test.sh \
+   /METviewer/bin/mv_test.sh \
+   /METviewer/bin/nightly_test.sh \
+   /METviewer/bin/prep_dist.sh \
+   /METviewer/bin/mv_compare.sh
+rm -r /METviewer/test
+
+# Change permissions of the scripts
+chmod 755 /METviewer/bin/*.sh

--- a/internal/scripts/docker/fix-permissions.sh
+++ b/internal/scripts/docker/fix-permissions.sh
@@ -2,6 +2,8 @@
 # Taken from https://raw.githubusercontent.com/openshift/sti-base/master/bin/fix-permissions
 # Fix permissions on the given directory to allow group read/write of
 # regular files and execute of directories.
-chgrp -R 0 $1
-chmod -R g+rw $1
-find $1 -type d -exec chmod g+x {} +
+if [ -d $1 ]; then 
+  chgrp -R 0 $1
+  chmod -R g+rw $1
+  find $1 -type d -exec chmod g+x {} +
+fi


### PR DESCRIPTION
## Pull Request Testing ##

These changes overhaul the METviewer Dockerfile setup to switch from the end-of-life centos7 base image to using the newly created `dtcenter/met-base-metviewer` Debian 12 base image.

- [x] Describe testing already performed for these changes:</br>
- Confirmed that the SonarQube GHA testing workflow runs fine (using `Dockerfile.copy`) on my feature branch. And it runs in 4+ minutes rather than 15+ minute previously.
- Confirmed that all 3 variations build fine on my laptop:
```
docker build -t mv_local --build-arg METVIEWER_GIT_NAME=feature_527_met_base_image .
docker build -t mv_local_copy --build-arg SOURCE_BRANCH=feature_527_met_base_image -f internal/scripts/docker/Dockerfile.copy .
docker build -t mv_local_apptainer --build-arg METVIEWER_GIT_NAME=feature_527_met_base_image -f Dockerfile.apptainer .
```

I also used DockerHub to test the builds for this feature branch:
- See [this build](https://hub.docker.com/repository/registry-1.docker.io/dtcenter/metviewer/builds/8eb7b0db-5bc3-45a8-92d2-bd7a7e9e0d57) of `dtcenter/METviewer` which uses `Dockerfile`.
- See [this build](https://hub.docker.com/repository/registry-1.docker.io/dtcenter/metviewer-singularity/builds/3586b4f6-f780-482e-8049-a0368b653d7a) of `dtcenter/METviewer-singularity` which uses `Dockerfile.apptainer`.
Both ran without error.

I did follow [these instructions](https://metplus-training.readthedocs.io/en/latest/modules/METviewer/docker.html) to run METviewer locally on my laptop. I was able to launch METviewer from my `feature_527_met_base_image` branch. I was only able to load the database by following other directions (that training needs to be updated). After loading the database, I was able to see the METviewer GUI and make a very basic plot.

I have not actually tested via Apptainer yet. That would be a great test to do.

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**
I made no changes to the user's guide. I did grep for "docker" in the user's guide and found no mention of it. So I figure there's nothing to be updated.

- [x] Do these changes include sufficient testing updates? **[No]**
There is no `testing.yml` workflow with automated tests for METviewer to be updated.

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>
There is no automated test suite to be modified.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:

- [x] Please complete this pull request review by **[Fri 7/5/24]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METviewer-X.Y.Z Development** project for official releases
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
