### PR TITLE
Bugfix 640 rscript y1 y2 points

### DIFF
--- a/R_tmpl/series_plot.R_tmpl
+++ b/R_tmpl/series_plot.R_tmpl
@@ -664,7 +664,7 @@ if( TRUE == boolDumpPoints1 ){
   listSeriesOrdered=list();
   oldInd=1;
   for(index in 1:length(listPlotOrderSeries1Part)){
-    newInd = (3 * listPlotOrderSeries1Part[index]) -2;
+    newInd = (3 * strtoi(listPlotOrderSeries1Part[index])) -2;
     for(i in 0:2){
       listSeriesOrdered[newInd+i]=listSeries1[oldInd+i];
     }
@@ -680,7 +680,7 @@ if( TRUE == boolDumpPoints2 && intNumSeries2){
   listSeriesOrdered=list();
   oldInd=1;
   for(index in 1:length(listPlotOrderSeries2Part)){
-    newInd = (3 * listPlotOrderSeries2Part[index]) -2;
+    newInd = (3 * strtoi(listPlotOrderSeries2Part[index])) -2;
     for(i in 0:2){
       listSeriesOrdered[newInd+i]=listSeries2[oldInd+i];
     }

--- a/R_tmpl/series_plot.R_tmpl
+++ b/R_tmpl/series_plot.R_tmpl
@@ -1042,7 +1042,7 @@ if( 0 < length(listDep2Plot) ){
     if( !listPlotDispSeries2[i] ){
       next;
     }
-    intStagIndex = listPlotOrderSeries2Part[i];
+    intStagIndex = strtoi(listPlotOrderSeries2Part[i]);
 
 
     # slice the series constituents from the series list


### PR DESCRIPTION
## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>


- on host 'dakota', generated the plots via METviewer UI via Rscript and can re-create the Rscript plots from  [original issue #395](https://github.com/dtcenter/METcalcpy/issues/395)

and request each variable on its own Y axis (Y1 for FSA, Y2 for OSA) and successfully save the Y1 and Y2 points.

- from command line, ran the Rscript generated by METviewer on 'dakota' via (as user vxwww):

`/nrit/ral/bin/Rscript /opt/tomcat9/vxwww/webapps/metviewer_output/scriptsplot_Rscript_FSA_Y1_OSA_Y2_synch.R`

and verified no errors and the .png and .points1 and .points2 files were generated and have expected content

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

- on dakota (preferably on Firefox or safari):

`http://dakota.rap.ucar.edu:8080/metviewer_dev/metviewer1.jsp
`

- Load the following XML config (remove .txt extension first):  

[plot_Rscript_FSA_Y1_OSA_Y2_synch.xml.txt](https://github.com/user-attachments/files/24058701/plot_Rscript_FSA_Y1_OSA_Y2_synch.xml.txt)

- The following plot should be generated (see /opt/tomcat9/vxwww/webapps/metviewer_output/plots as user vxwww)

<img width="792" height="612" alt="plot_Rscript_FSA_Y1_OSA_Y2_synch" src="https://github.com/user-attachments/assets/b5f97cfd-cda6-4788-b005-5ddc0ccc6584" />




with the following Y1 and Y2 points (see /opt/tomcat9/vxwww/webapps/metviewer_output/data as user vxwww)

[plot_Rscript_FSA_Y1_OSA_Y2_synch.points1.txt](https://github.com/user-attachments/files/24058725/plot_Rscript_FSA_Y1_OSA_Y2_synch.points1.txt)

[plot_Rscript_FSA_Y1_OSA_Y2_synch.points2.txt](https://github.com/user-attachments/files/24058722/plot_Rscript_FSA_Y1_OSA_Y2_synch.points2.txt)




- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[NA]**

- [x ] Do these changes include sufficient testing updates? **[NA]**

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Do these changes introduce new SonarQube findings? **[Yes]**</br>
If **yes**, please describe: Test coverage threshold will not be met

- [x] Please complete this pull request review by **[beta1 release]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METviewer-X.Y.Z Development** project for official releases
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
